### PR TITLE
pass cognito user id on register success response/callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file. This change
 
 ## [UNRELEASED]
 
+## 0.1.1-alpha - 2025-08-22
+### Changed
+- Now `::user-register` handler in `:on-success-evt` callback will pass map with `:user-id` from cognito signup.
+
 ## 0.1.1-alpha - 2023-07-19
 ### Changed
 - The id-token 'payload' provided by the session coeffect is now a
@@ -15,7 +19,8 @@ All notable changes to this project will be documented in this file. This change
 ### Added
 - Initial commit
 
-[UNRELEASED]:  https://github.com/gethop-dev/session.re-frame.cognito/compare/v0.1.1-alpha...HEAD
+[UNRELEASED]:  https://github.com/gethop-dev/session.re-frame.cognito/compare/v0.1.2-alpha...HEAD
+[0.1.2]:  https://github.com/gethop-dev/session.re-frame.cognito/compare/v0.1.1-alpha...v0.1.2-alpha
 [0.1.1]:  https://github.com/gethop-dev/session.re-frame.cognito/compare/v0.1.0-alpha...v0.1.1-alpha
 [0.1.0]: https://github.com/gethop-dev/session.re-frame.cognito/releases/tag/v0.1.0-alpha
 =======

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dev.gethop/session.re-frame.cognito "0.1.2-alpha-SNAPSHOT"
+(defproject dev.gethop/session.re-frame.cognito "0.1.2-alpha"
   :description "Re-frame library for session management using AWS Cognito"
   :url "https://github.com/gethop-dev/session.re-frame.cognito"
   :license {:name "Mozilla Public License 2.0"

--- a/src/dev/gethop/session/re_frame/cognito/action/register.cljs
+++ b/src/dev/gethop/session/re_frame/cognito/action/register.cljs
@@ -39,10 +39,10 @@
       @state/cognito-user-obj
       verification-code
       true
-      (fn [error _result]
+      (fn [error result]
         (if error
           (rf/dispatch [::util/generic-failure on-failure-evt error])
-          (rf/dispatch [::util/generic-success on-success-evt])))))))
+          (rf/dispatch [::util/generic-success on-success-evt {:user-id (.userSub result)}])))))))
 
 (rf/reg-event-fx
  ::user-confirm-registration

--- a/src/dev/gethop/session/re_frame/cognito/util.cljs
+++ b/src/dev/gethop/session/re_frame/cognito/util.cljs
@@ -8,9 +8,9 @@
 
 (rf/reg-event-fx
  ::generic-success
- (fn [_ [_ on-success-evt]]
+ (fn [_ [_ on-success-evt result]]
    (if on-success-evt
-     {:dispatch on-success-evt}
+     {:dispatch (conj on-success-evt result)}
      {})))
 
 (rf/reg-event-fx


### PR DESCRIPTION
Now `::user-register` handler in `:on-success-evt` callback will pass map with `:user-id` from cognito signup.